### PR TITLE
textlint-rule-preset-ai-writingを追加

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -5,6 +5,7 @@
         "allowEmojiAtEnd": true,
         "allowPeriodMarks": [":"]
       }
-    }
+    },
+    "preset-ai-writing": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "textlint": "^15.1.0",
+        "textlint-rule-preset-ai-writing": "^1.1.0",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2"
       }
     },
@@ -4998,6 +4999,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/hata6502"
+      }
+    },
+    "node_modules/textlint-rule-preset-ai-writing": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-ai-writing/-/textlint-rule-preset-ai-writing-1.1.0.tgz",
+      "integrity": "sha512-bZEIdShA7RI0U1PkTA5K8PkDsh7LGs24nLQpnKgkfvcGfXEXZNRNGfS/b3oZQd4A4xydNCMKgk5M1+JKDKWFCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/regexp-string-matcher": "^2.0.2",
+        "textlint-util-to-string": "^3.3.4"
+      }
+    },
+    "node_modules/textlint-rule-preset-ai-writing/node_modules/@textlint/regexp-string-matcher": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@textlint/regexp-string-matcher/-/regexp-string-matcher-2.0.2.tgz",
+      "integrity": "sha512-OXLD9XRxMhd3S0LWuPHpiARQOI7z9tCOs0FsynccW2lmyZzHHFJ9/eR6kuK9xF459Qf+740qI5h+/0cx+NljzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqwith": "^4.5.0"
       }
     },
     "node_modules/textlint-rule-preset-ja-technical-writing": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "textlint": "^15.1.0",
+    "textlint-rule-preset-ai-writing": "^1.1.0",
     "textlint-rule-preset-ja-technical-writing": "^12.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- AI支援によるテクニカルライティング品質分析ツールを導入
- 効果的なテクニカルライティングの7つのC原則に基づく改善提案機能を追加

## 変更内容
- `textlint-rule-preset-ai-writing` v1.1.0をdevDependenciesに追加
- `.textlintrc.json`にai-writingプリセットを設定
- 既存のja-technical-writingプリセットと併用

## 新機能
- **7つのC原則**: Clear, Concise, Correct, Coherent, Concrete, Complete, Courteous
- **簡潔性チェック**: 冗長な義務表現の検出・改善提案
- **品質分析**: 文書全体の改善可能性を数値化

## テストプラン
- [ ] CIでtextlintが正常に実行されることを確認
- [ ] ai-writingルールがinfo レベルで適切に動作することを確認
- [ ] 既存のja-technical-writingルールとの共存を確認

🤖 Generated with [Claude Code](https://claude.ai/code)