### PR TITLE
feat: WSL環境でWindows ChromeにCDP経由でplaywright-mcpを接続する記事を追加

### DIFF
--- a/articles/e1e5bcb477d36c.md
+++ b/articles/e1e5bcb477d36c.md
@@ -1,0 +1,199 @@
+---
+title: "WSL環境でWindows ChromeにCDP経由でplaywright-mcpを接続する"
+emoji: "🎭"
+type: "tech"
+topics: ["wsl", "chrome", "playwright", "mcp", "claudecode"]
+published: false
+---
+
+## はじめに
+
+WSL環境でブラウザ自動化を行いたい場合、LinuxのGUI環境を用意するか、Windows側のブラウザと連携する必要があります。本記事では、Chrome DevTools Protocol (CDP)を使用して、WSL環境からWindows側のChromeに接続し、Claude CodeのMCP (Model Context Protocol) 経由でplaywrightを操作する方法を紹介します。
+
+## 必要な環境
+
+- WSL2（mirrored networking mode設定済み）
+- Windows側のGoogle Chrome
+- Claude Code (claude.ai/code)
+
+## WSL2のネットワーク設定
+
+### mirroredモードの必要性
+
+WSL2のデフォルトのネットワークモード（NAT）では、WSL2とWindowsホストは別々の仮想ネットワーク上に存在します。このため、それぞれの`localhost`は異なるマシンを指すことになります。
+
+- WSL2内で`localhost`を使うと、それはWSL2自身を指す
+- Windows側で起動したサービスにWSL2から`localhost`でアクセスできない
+
+この問題を解決するために、WSL2のネットワークモードを**mirrored**に変更する必要があります。
+
+### mirroredモードの設定方法
+
+`~/.wslconfig`（Windowsホーム配下）に以下を記述します：
+
+```ini
+[wsl2]
+networkingMode=mirrored
+```
+
+設定後、WSLを再起動します：
+
+```powershell
+wsl --shutdown
+```
+
+mirroredモードでは、WindowsとWSL2が同じネットワークインターフェースを共有するため、`localhost`が両環境で同じ意味を持つようになります。
+
+## セットアップ手順
+
+### Chrome起動スクリプトの作成
+
+まず、Windows側のChromeをリモートデバッグモードで起動するスクリプトを作成します。
+
+```bash:~/.claude/launch-chrome.sh
+#!/bin/bash
+
+# WSL環境でWindows側のChromeを使用するため、/mnt/c/経由でアクセス
+CHROME_PATH="/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"
+
+echo "Starting Chrome with remote debugging on port 9222..."
+
+"$CHROME_PATH" \
+  --remote-debugging-port=9222 \
+  --no-first-run \
+  --no-default-browser-check \
+  --disable-gpu \
+  --user-data-dir=C:\\temp\\chrome-debug > /dev/null 2>&1 &  # 通常のプロファイルと干渉しないよう別ディレクトリを使用
+
+sleep 3  # Chromeの起動に時間がかかるため待機（短すぎると接続エラー）
+
+echo "Getting WebSocket endpoint..."
+curl http://localhost:9222/json/version 2>/dev/null
+```
+
+実行権限を付与します：
+
+```bash
+chmod +x ~/.claude/launch-chrome.sh
+```
+
+### playwright MCPサーバーの登録
+
+次に、playwright MCPサーバーをClaude Codeに登録します。
+
+```bash:~/.claude/register_mcp.sh
+#!/bin/bash
+
+claude mcp add playwright -s user -- npx -y @playwright/mcp@latest --cdp-endpoint http://localhost:9222
+```
+
+実行権限を付与して実行：
+
+```bash
+chmod +x ~/.claude/register_mcp.sh
+~/.claude/register_mcp.sh
+```
+
+### Claude Codeの設定
+
+Claude Codeの設定ファイルで、playwright MCPの使用を許可します。
+
+```json:~/.claude/settings.json
+{
+  "mcp": {
+    "approvedTools": [
+      "mcp__playwright"
+    ]
+  }
+}
+```
+
+## 使い方
+
+### Chromeの起動
+
+1. スクリプトを実行してChromeを起動します：
+
+```bash
+~/.claude/launch-chrome.sh
+```
+
+2. 以下のようなWebSocketエンドポイント情報が表示されます：
+
+```json
+{
+  "Browser": "Chrome/xxx.x.xxxx.xxx",
+  "Protocol-Version": "1.3",
+  "User-Agent": "...",
+  "V8-Version": "...",
+  "WebKit-Version": "...",
+  "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser/..."
+}
+```
+
+### Claude Codeでのplaywright操作
+
+Claude Codeで以下のようなコマンドを実行できます：
+
+```
+ブラウザで https://example.com を開いて
+```
+
+```
+スクリーンショットを撮って
+```
+
+```
+"ボタン"というテキストをクリックして
+```
+
+## 実装のポイント
+
+### 起動待機時間の重要性
+
+`sleep 3`の部分は重要です。Chromeの起動に時間がかかるため、すぐにCDP接続を試みると失敗します。環境によっては調整が必要です。
+
+### ポート9222の選定理由
+
+9222ポートはChromeのリモートデバッグで一般的に使用されるポートです。他のアプリケーションと競合しにくく、覚えやすい番号です。
+
+### 別プロファイルの使用
+
+`--user-data-dir=C:\\temp\\chrome-debug`で別のプロファイルディレクトリを指定しています。Chromeのリモートデバッグでは、セキュリティと安定性の観点から別プロファイルの使用が推奨されており、特に最近のバージョンでは事実上必須となっています。
+
+別プロファイルを使用する利点：
+- 通常使用しているChromeプロファイルに影響を与えない
+- クリーンな環境でテストができる
+- 複数のChromeインスタンスを同時に実行できる
+- 拡張機能やキャッシュの影響を受けない
+
+## トラブルシューティング
+
+### 接続エラーの対処法
+
+「Connection refused」エラーが出る場合：
+1. Chromeが正しく起動しているか確認
+2. ポート9222が他のプロセスで使用されていないか確認
+3. 起動待機時間を長くしてみる
+
+### Chromeが起動しない場合
+
+1. Chromeのパスが正しいか確認
+2. WSL環境からWindows側の実行ファイルにアクセスできるか確認
+3. ファイアウォールの設定を確認
+
+### 権限関連の問題
+
+1. スクリプトに実行権限があるか確認
+2. Claude Codeの設定でMCPツールが許可されているか確認
+
+## まとめ
+
+WSL環境でWindows側のChromeをCDP経由で操作することで、GUI環境を用意することなくブラウザ自動化が実現できました。Claude CodeのMCP機能と組み合わせることで、自然言語でブラウザ操作を指示できるようになり、開発効率が大幅に向上します。
+
+今後の改善点としては：
+- 複数のブラウザインスタンスの管理
+- エラーハンドリングの強化
+- より詳細な設定オプションの追加
+
+などが考えられます。WSL環境でのブラウザ自動化にお困りの方の参考になれば幸いです。


### PR DESCRIPTION
## Summary
- WSL2環境でWindows側のChromeをCDP経由で操作する方法を解説する記事を追加
- mirroredネットワークモードの必要性と設定方法を説明
- Claude CodeのMCP機能と組み合わせたブラウザ自動化の実現方法を紹介

## Test plan
- [ ] 記事のマークダウンが正しくレンダリングされることを確認
- [ ] コードブロックの構文ハイライトが適用されることを確認
- [ ] `npx zenn preview`でローカルプレビューを確認

🤖 Generated with [Claude Code](https://claude.ai/code)