### PR TITLE
WSL2 で wrangler login が終わらないときは --callback-host 0.0.0.0

### DIFF
--- a/articles/0da58728c86336.md
+++ b/articles/0da58728c86336.md
@@ -1,0 +1,55 @@
+---
+title: "WSL2 で wrangler login が終わらないときは --callback-host 0.0.0.0"
+emoji: "⛅"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["cloudflare", "wrangler", "wsl", "wsl2"]
+published: true
+publication_name: pepabo
+---
+
+WSL2 で `wrangler login` を実行してブラウザで認証を済ませたのに、ターミナルが反応しないまま止まってしまうことがあります。
+
+```bash
+$ wrangler login
+ ⛅️ wrangler 4.x.x
+--------------------
+Attempting to login via OAuth...
+Opening a link in your default browser: https://dash.cloudflare.com/oauth2/auth?...
+```
+
+ブラウザには「ログイン成功」と表示されているのに、ターミナル側は無反応のまま。
+
+## なぜ止まるのか
+
+Wrangler はログイン時に `localhost:8976` でコールバック用の HTTP サーバーを立て、ブラウザがそこへリダイレクトされることでトークンを受け取る仕組みになっています。コールバック URL は [`generate-auth-url.ts`](https://github.com/cloudflare/workers-sdk/blob/d0f0159996aaee6d59f96c785c33a62628ef1108/packages/wrangler/src/user/generate-auth-url.ts#L9) にハードコードされています。
+
+```ts
+export const OAUTH_CALLBACK_URL = "http://localhost:8976/oauth/callback";
+```
+
+デフォルトではこのサーバーを [`user.ts`](https://github.com/cloudflare/workers-sdk/blob/d0f0159996aaee6d59f96c785c33a62628ef1108/packages/wrangler/src/user/user.ts#L1137) で `127.0.0.1` のみにバインドしています。
+
+```ts
+server.listen(options.callbackPort, options.callbackHost);
+// デフォルト: callbackHost = "localhost", callbackPort = 8976
+```
+
+WSL2 の NAT モード（デフォルト）では、Windows 側ブラウザから WSL 内の `127.0.0.1:8976` に届かないケースがあります。認証は完了してもコールバックが WSL 内サーバーに到達せず、ハングしたように見えます。
+
+## 解決策
+
+`--callback-host 0.0.0.0` を付けるだけです。
+
+```bash
+wrangler login --callback-host 0.0.0.0
+```
+
+これで Wrangler が全インターフェースを listen するようになります。WSL2 の localhost フォワーディングが有効なら、Windows 側ブラウザからのコールバックが届くようになります。
+
+なお、`redirect_uri`（Cloudflare の OAuth サーバーに送るコールバック URL）は [PR #9396](https://github.com/cloudflare/workers-sdk/pull/9396) 以降、常に `localhost:8976` のままです。`--callback-host` はバインドアドレスだけを変えます。
+
+## 補足：古い Wrangler では `--callback-host 0.0.0.0` 自体が壊れていた
+
+以前のバージョンでは、`--callback-host 0.0.0.0` を指定すると `redirect_uri` まで `0.0.0.0` になってしまうバグがありました（[Issue #10603](https://github.com/cloudflare/workers-sdk/issues/10603)）。Cloudflare の OAuth サーバーが `0.0.0.0` を `redirect_uri` として拒否するため、そもそも認証画面が開かないという状況でした。
+
+このバグは **wrangler 4.59.3** で修正されています（[PR #9396](https://github.com/cloudflare/workers-sdk/pull/9396)、2026 年 1 月 20 日マージ）。古いバージョンをお使いの場合はアップデートしてから試してみてください。


### PR DESCRIPTION
WSL2 環境で `wrangler login` が OAuth コールバックを受け取れずにハングする問題と、`--callback-host 0.0.0.0` による解決策を記事にしました。

publication: pepabo