### PR TITLE
記事追加: herdrのセッション復元でCLIオプションが引き継がれないのでシェルのラッパー関数で回避する

### DIFF
--- a/articles/19a24f30c2edb9.md
+++ b/articles/19a24f30c2edb9.md
@@ -1,0 +1,59 @@
+---
+title: "herdrのセッション復元でCLIオプションが引き継がれないのでシェルのラッパー関数で回避する"
+emoji: "🐚"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["herdr", "claudecode", "fish", "wsl2"]
+published: true
+publication_name: pepabo
+---
+
+筆者は、コーディングエージェント向けのターミナルマルチプレクサ herdr で Claude Code を動かしています。Claude Code でブラウザ連携（Claude in Chrome）を使うには、`claude --chrome` のようにオプションを付けて起動しておく必要があります。
+
+このオプションを毎回付けるのは面倒なので常時有効にしたいのですが、herdr 上だと一筋縄ではいきませんでした。
+
+## herdr のセッション復元はオプションを引き継がない
+
+Claude Code の `/chrome` コマンドには「Enabled by default」という設定があり、本来はこれを有効にすれば毎回オプションを付ける必要はありません。しかし筆者の WSL 環境ではこの設定が使えませんでした。
+
+それなら herdr のペインを `claude --chrome` で起動すればよさそうです。しかし herdr は、サーバーの再起動後などにセッションを復元するとき、固定で `claude --resume <session-id>` を実行します。起動時に付けていた `--chrome` は、復元のたびに失われてしまいます。
+
+この問題は herdr 側でも報告されています。[Issue #965](https://github.com/ogulcancelik/herdr/issues/965) を見ると、失われるのはオプションだけでなく、環境変数や作業ディレクトリも同様です。[Discussion #632](https://github.com/ogulcancelik/herdr/discussions/632) では、起動時の `launch_argv` を記録して復元時に再現する提案も出ています。しかし、いまのところ herdr 側で対応される予定はなさそうです。
+
+## シェルのラッパー関数でオプションを付与する
+
+herdr がどんなコマンドで復元しようとも、シェル側で `claude` コマンド自体をラップしてしまえば確実です。筆者は fish を使っているので、`~/.config/fish/functions/claude.fish` に次の関数を置きました。
+
+```fish
+function claude --wraps claude --description 'claude with --chrome enabled by default'
+    if contains -- --chrome $argv; or contains -- -p $argv; or contains -- --print $argv
+        command claude $argv
+    else
+        command claude --chrome $argv
+    end
+end
+```
+
+fish は `~/.config/fish/functions/` に置いたファイルを関数として自動読み込みするので、ファイルを置くだけで有効になります。
+
+関数の中では `command claude` と書いて、実体のコマンドを直接呼び出しています。これを忘れると、関数が自分自身を呼んで無限ループになります。`--wraps claude` は補完を引き継ぐための指定です。これで本体の `claude` コマンドと同じ補完が使えます。
+
+条件分岐では、`--chrome` が不要なケースを先に処理しています。すでに指定されている場合の二重付与を防ぐほか、`-p` / `--print` による非対話実行ではブラウザ連携を使わないためです。エイリアスではなく関数でラップしているのは、この条件分岐を書くためです。
+
+herdr のペイン内ではコマンドがシェルを介して実行されるため、セッション復元時の `claude --resume <session-id>` もこの関数を通ります。これで復元後のセッションでもブラウザ連携が有効なままになりました。
+
+fish は一例で、同じことはほかのシェルでもできます。bash や zsh なら、次のような関数を設定ファイルに書けば同等になります。
+
+```bash
+claude() {
+    case " $* " in
+        *" --chrome "* | *" -p "* | *" --print "*) command claude "$@" ;;
+        *) command claude --chrome "$@" ;;
+    esac
+}
+```
+
+## まとめ
+
+herdr のセッション復元でオプションが失われる問題を、シェルのラッパー関数で回避しました。
+
+Discussion #632 には、`--dangerously-skip-permissions` や `--model` が失われて困るという報告もあります。それらのオプションを常用したい場合にも、同じ方法を応用できるはずです。


### PR DESCRIPTION
## 概要

herdr のセッション復元で CLI オプションが引き継がれない問題を、シェルのラッパー関数で回避する記事を追加します。

- 課題: herdr は復元時に固定で `claude --resume <id>` を実行するため、`--chrome` などの起動オプションが失われる（herdr 側に対応予定はなさそう）
- 解決策: シェルの `claude` ラッパー関数でオプションを付与する（fish を例に、bash / zsh 版も掲載）

元ネタ: kenchan/dotfiles@d7a0218

## チェック

- [x] textlint（自動修正 + lintFile）指摘なし
- [x] topics（herdr / claudecode / fish / wsl2）がZennに存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122caESuv55Kyvyo4Y91cPv