### PR TITLE
一人称を「筆者」から「私」に変更

### DIFF
--- a/articles/19a24f30c2edb9.md
+++ b/articles/19a24f30c2edb9.md
@@ -7,13 +7,13 @@ published: true
 publication_name: pepabo
 ---
 
-筆者は、コーディングエージェント向けのターミナルマルチプレクサ herdr で Claude Code を動かしています。Claude Code でブラウザ連携（Claude in Chrome）を使うには、`claude --chrome` のようにオプションを付けて起動しておく必要があります。
+私は、コーディングエージェント向けのターミナルマルチプレクサ herdr で Claude Code を動かしています。Claude Code でブラウザ連携（Claude in Chrome）を使うには、`claude --chrome` のようにオプションを付けて起動しておく必要があります。
 
 このオプションを毎回付けるのは面倒なので常時有効にしたいのですが、herdr 上だと一筋縄ではいきませんでした。
 
 ## herdr のセッション復元はオプションを引き継がない
 
-Claude Code の `/chrome` コマンドには「Enabled by default」という設定があり、本来はこれを有効にすれば毎回オプションを付ける必要はありません。しかし筆者の WSL 環境ではこの設定が使えませんでした。
+Claude Code の `/chrome` コマンドには「Enabled by default」という設定があり、本来はこれを有効にすれば毎回オプションを付ける必要はありません。しかし私の WSL 環境ではこの設定が使えませんでした。
 
 それなら herdr のペインを `claude --chrome` で起動すればよさそうです。しかし herdr は、サーバーの再起動後などにセッションを復元するとき、固定で `claude --resume <session-id>` を実行します。起動時に付けていた `--chrome` は、復元のたびに失われてしまいます。
 
@@ -21,7 +21,7 @@ Claude Code の `/chrome` コマンドには「Enabled by default」という設
 
 ## シェルのラッパー関数でオプションを付与する
 
-herdr がどんなコマンドで復元しようとも、シェル側で `claude` コマンド自体をラップしてしまえば確実です。筆者は fish を使っているので、`~/.config/fish/functions/claude.fish` に次の関数を置きました。
+herdr がどんなコマンドで復元しようとも、シェル側で `claude` コマンド自体をラップしてしまえば確実です。私は fish を使っているので、`~/.config/fish/functions/claude.fish` に次の関数を置きました。
 
 ```fish
 function claude --wraps claude --description 'claude with --chrome enabled by default'


### PR DESCRIPTION
記事 19a24f30c2edb9 の一人称を「筆者」から「私」に変更します（3箇所）。textlintはローカルで指摘なしを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122caESuv55Kyvyo4Y91cPv