### PR TITLE
japanese-tech-writingスキルをsubmoduleとして導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "weekly"
     reviewers:
       - "kenchan"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "kenchan"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".claude/skills/japanese-tech-writing"]
+	path = .claude/skills/japanese-tech-writing
+	url = https://gist.github.com/fd287c3133457c4fd8f5601d34aa817d.git


### PR DESCRIPTION
## 概要

記事レビューで参照している [k16shikanoさんの日本語技術文書の文章規範Gist](https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d) を、`.claude/skills/japanese-tech-writing` にgit submoduleとして取り込みます。GistはSKILL.md 1ファイル構成でフロントマターも揃っているため、そのままClaude Codeのスキルとして機能します。

## 上流の更新追従

`.github/dependabot.yml` に `gitsubmodule` ecosystemを追加しました。Gistが更新されると週次でDependabotが更新PRを作成します（既存のauto-merge workflowの対象にもなります）。

手動で更新したい場合:

```bash
git submodule update --remote .claude/skills/japanese-tech-writing
```

## 備考

- CIのtextlintは `articles/` `books/` のみ対象のため、SKILL.mdは校正対象になりません
- clone直後は `git submodule update --init` が必要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122caESuv55Kyvyo4Y91cPv