### PR TITLE
Issue #965の作業ディレクトリに関する記述を原文に即して修正

### DIFF
--- a/articles/19a24f30c2edb9.md
+++ b/articles/19a24f30c2edb9.md
@@ -17,7 +17,7 @@ Claude Code の `/chrome` コマンドには「Enabled by default」という設
 
 それなら herdr のペインを `claude --chrome` で起動すればよさそうです。しかし herdr は、サーバーの再起動後などにセッションを復元するとき、固定で `claude --resume <session-id>` を実行します。起動時に付けていた `--chrome` は、復元のたびに失われてしまいます。
 
-この問題は herdr 側でも報告されています。[Issue #965](https://github.com/ogulcancelik/herdr/issues/965) を見ると、失われるのはオプションだけでなく、環境変数や作業ディレクトリも同様です。[Discussion #632](https://github.com/ogulcancelik/herdr/discussions/632) では、起動時の `launch_argv` を記録して復元時に再現する提案も出ています。しかし、いまのところ herdr 側で対応される予定はなさそうです。
+この問題は herdr 側でも報告されています。[Issue #965](https://github.com/ogulcancelik/herdr/issues/965) では、オプションのほかに環境変数も失われ、作業ディレクトリもタブ作成時のものに戻ってしまう（ペインで移動した先は反映されない）とされています。[Discussion #632](https://github.com/ogulcancelik/herdr/discussions/632) では、起動時の `launch_argv` を記録して復元時に再現する提案も出ています。しかし、いまのところ herdr 側で対応される予定はなさそうです。
 
 ## シェルのラッパー関数でオプションを付与する
 


### PR DESCRIPTION
「環境変数や作業ディレクトリも同様（に失われる）」という記述は不正確だったため修正します。

Issue #965 の原文は "the pane restarts at the TAB's creation cwd, not the directory the pane was actually working in" で、作業ディレクトリは「失われる」のではなく「タブ作成時のものに戻り、ペインで移動した先が反映されない」という報告です。環境変数（unset）と同列にくくらない表現に改めました。textlintはローカルで指摘なしを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122caESuv55Kyvyo4Y91cPv