### PR TITLE
herdr-ghq-open-agentプラグインの記事を追加

### DIFF
--- a/articles/ef0834b827f6ca.md
+++ b/articles/ef0834b827f6ca.md
@@ -1,0 +1,182 @@
+---
+title: "ghqとfzfでclaudeを起動するherdrプラグインを作って学んだこと"
+emoji: "🧩"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["herdr", "claudecode", "bash", "ai"]
+published: false
+publication_name: pepabo
+---
+
+[herdr](https://herdr.dev)は、コーディングエージェント向けのターミナルマルチプレクサです。私がherdrで作業を始めるときの流れは大体決まっていて、その流れをワンキーで実行するherdrプラグイン[herdr-ghq-open-agent](https://github.com/kenchan/herdr-ghq-open-agent)を作りました。ghqと[fzf](https://github.com/junegunn/fzf)でリポジトリを選択し、herdrのworkspaceまたはtabで開いてClaude Codeを起動する、という流れです。皆さんも同じような処理を自分で、もしくはAIエージェントへの指示で繰り返しているのではないでしょうか。
+
+この記事では、そのプラグインの紹介と作る過程で得た学びをまとめます。
+
+## 作ったもの
+
+herdr-ghq-open-agentは、設定したキーバインドでpopupを開き、fzfでリポジトリを選ぶと次の動きをします。
+
+- 選んだリポジトリのディレクトリで動作中のworkspaceがあれば、そこに新しいtabを追加する
+- なければ新しいworkspaceを作る
+- paneのシェルが起動したら、`herdr agent start`でClaude Codeを起動する
+
+インストールは1コマンドです。
+
+```sh
+herdr plugin install kenchan/herdr-ghq-open-agent
+```
+
+呼び出しはキーに割り当てるので、`~/.config/herdr/config.toml` に次のように書きます。
+
+```toml
+[[keys.command]]
+key = "prefix+t"
+type = "shell"
+command = '"$HERDR_BIN_PATH" plugin pane open --plugin kenchan.ghq-open-agent --entrypoint picker'
+```
+
+素の`herdr`ではなく`$HERDR_BIN_PATH`を使う理由は後述します。実装は`picker.sh`(bash、112行)と`herdr-plugin.toml`の2ファイルで、設定ファイルはありません。現在はfzfとClaude Codeの利用を決め打ちしています。
+
+## 仕組み
+
+herdrのプラグインは、`herdr-plugin.toml`というマニフェストと、任意の言語で書いたコマンドの組み合わせです。マニフェストがpaneやactionなどのエントリポイントを宣言し、起動されたコマンドは`herdr workspace create`のようなherdr CLIを呼んでセッションを操作します。今回のマニフェストは次のとおりです。
+
+```toml
+id = "kenchan.ghq-open-agent"
+name = "ghq Open Agent"
+version = "0.1.0"
+min_herdr_version = "0.7.5"
+platforms = ["linux", "macos"]
+
+[[panes]]
+id = "picker"
+title = "ghq"
+placement = "popup"
+width = "80%"
+height = "80%"
+command = ["bash", "picker.sh"]
+```
+
+fzfのようなTUIには実際の端末が必要なので、plugin actionではなく`placement = "popup"`のpane(80%×80%のフローティングターミナル)と定義しています。
+
+`picker.sh`は、シェルスクリプトで書かれた一連のコマンド呼び出しです。
+
+1. `ghq list --full-path | fzf`でリポジトリを選択する
+2. `pane list`で全paneのcwdを照合し、選択したリポジトリで動作中のworkspaceを探す
+3. 見つかれば`tab create`でそのworkspaceにtabを追加し、なければ`workspace create`で新規作成する
+4. `pane wait-output --regex '\S'`で、paneに何か出力される(=シェルのプロンプトが出る)まで待つ
+5. `agent start --kind claude --pane <pane_id>`でClaude Codeを起動する
+
+`herdr agent start`は、シェルプロンプト状態のpaneの中でagentを起動するコマンドです。paneの中でclaudeを起動し、同じ端末内でclaudeが検出されて入力待ちになるまでブロックします。paneに`claude`と手で打ち込んだ場合も、herdrは実行中のagentを自動検出します。`herdr agent start`を使う利点は、起動の成否がコマンドの終了で確定することと、後から操作するための名前を起動時に付けられることです。
+
+cwdでworkspaceを検索する専用のAPIはありませんが、`pane list`は全paneをcwdとworkspace_id付きで返します。選択したパスとcwdを照合し、最初に一致したpaneのworkspaceを再利用することにしています。
+
+```sh
+existing_workspace_id=$("$HERDR" pane list | jq -r --arg p "$selected_path" \
+  '[.result.panes[] | select(.cwd == $p or (.cwd | startswith($p + "/")))][0].workspace_id // empty')
+```
+
+agent名には`[a-z][a-z0-9_-]{0,31}`という制約があるため、リポジトリ名を小文字化し、英数字以外を`-`へ潰して`ghq-<リポジトリ名>`の形に正規化します。既存のagent名と衝突する場合は`-2`、`-3`とサフィックスを足します。また`pane wait-output`がマッチした直後でも、paneのシェルはまだagentの起動を受け付けられないことがあり、`agent start`が`agent_pane_busy`を返します。このエラーコードに限り、最大10回リトライします。
+
+設定機構は持たせませんでした。herdr v1のconfig.tomlにプラグインの独自の設定を持つためのセクションはなく、`HERDR_PLUGIN_CONFIG_DIR`配下に自前のファイルを置く方式になります。検索コマンドのfzf以外への切り替えや、Claude Code以外のエージェントの利用は、いずれ欲しくなるはずです。ただ、プラグインが設定を持つためのスタンダードな方法がそのうち確立されるだろうと考えて、保留にしています。
+
+## 学び1: type = "shell"はログインシェルで実行される
+
+インストール直後に、この罠を踏みました。`type = "shell"`のキーバインドから`herdr plugin pane open ...`を実行しても何も起きません。標準出力やエラーは出ず、popupも開きません。
+
+herdrのソースを読むと、`shell`型のカスタムコマンドは`/bin/sh -lc '<command>'`として実行されていました。`-l`はログインシェルとしての起動を意味し、`/etc/profile`が読み込まれます。多くの環境の`/etc/profile`はPATHをシステムデフォルトで上書きするため、呼び出し元から継承したPATHはそこで消えます。
+
+```sh
+$ /bin/sh -c 'echo $PATH'    # 呼び出し元のPATHをそのまま継承する
+/home/kenchan/.local/bin:/home/kenchan/.local/share/mise/installs/...(略)
+
+$ /bin/sh -lc 'echo $PATH'   # /etc/profileがPATHを上書きする
+/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/opt/cuda/bin
+```
+
+私はmiseでherdrを導入しているので、実体はmiseが管理するディレクトリ(`~/.local/share/mise/installs/`配下)にあります。ログインシェルのPATHにこのディレクトリは含まれず、`herdr`コマンドは解決できないという問題がおきました。
+
+「作ったもの」のキーバインド例で素の`herdr`ではなく`"$HERDR_BIN_PATH"`を使っているのは、この罠を避けるためです。`HERDR_BIN_PATH`は、herdrがキーバインドやプラグインのコマンド環境に注入する、実行中バイナリの絶対パスです。PATHの解決を経由しないため、`/etc/profile`が何をしようと影響を受けません。同じ理由で、`picker.sh`内のherdr呼び出しもすべて`${HERDR_BIN_PATH:-herdr}`経由にしています。mise、asdfなどのバージョンマネージャでherdrを導入している場合は必ず踏む罠なので、herdrプラグインを作成する方は覚えておくとよさそうです。
+
+## 学び2: popupの寿命と同期処理は分離する
+
+herdrのpopup placementは、コマンドの終了とともに閉じます。裏を返すと、コマンドが動いているあいだは閉じません。今回のような処理をそのまま直列に実装すると、リポジトリの選択後も同期処理が続きます。workspaceの作成、シェルの起動待ち、そして`agent start`です。`agent start`はagentの検出完了までブロックし、早くても数秒かかります。そうなると、fzfが消えた後の空のpopupが画面に残り続けて気になってしまいます。
+
+そこでスクリプトを2フェーズに分けました。popupフェーズはfzfの選択が終わったら、自分自身を`--open`フラグ付きで切り離して起動(detached起動)し、即座にexitします。これでpopupは選択直後に閉じます。`--open`で起動されたworkerフェーズが、workspaceとtabの作成、agent起動を裏で続行します。
+
+```sh
+if [ "${1:-}" = "--open" ]; then
+  open_repo "$2"    # workspace/tabの作成とagent起動
+  exit 0
+fi
+
+selected_path=$(ghq list --full-path | fzf --height=40% --reverse)
+
+trap '' HUP
+setsid bash "$script_path" --open "$selected_path" </dev/null >/dev/null 2>&1 &
+exit 0
+```
+
+workerにTTYはないので、エラーは`herdr notification show`のtoastで通知します。ただしpopupの破棄中に送ったtoastは、APIが成功を返しても表示されないことがあります。レスポンスの`.result.shown`が`false`の場合に限り、0.1秒待って1回再送しています。
+
+このコードの`trap '' HUP`が、次の学びの主題です。
+
+## 学び3: fork()とsetsid()のあいだにSIGHUPが割り込む
+
+detached起動は、最初`trap '' HUP`なしで実装していました。するとworkerは、何も実行せずに死にました。
+
+何が起きたかを順に追います。popupフェーズのbashがexitすると、herdrはpaneを破棄し、popupのPTYを閉じます。このPTYはpopup内のプロセスの制御端末なので、カーネルは端末の切断(hangup)として、フォアグラウンドプロセスグループへSIGHUPを送ります。
+
+問題はworkerの位置です。ジョブ制御が無効な非対話シェルでは、`&`で起動した子も親と同じプロセスグループに属します。`setsid`コマンドが実行されればworkerは新しいセッションへ移りますが、bashのfork()から`setsid(2)`の呼び出しまでには隙間があります。PTYの破棄がこの隙間に重なると、まだ旧グループにいる子がSIGHUPを受け、デフォルト動作の終了で死にます。
+
+この競合は`script(1)`で再現できます。`script`は新しいPTYを割り当ててコマンドを実行し、コマンドの終了とともにPTYを破棄するので、「親の即exitでPTYが破棄される」状況をそのまま作れます。
+
+```sh
+script -qec '(setsid bash worker.sh &); exit 0' /dev/null
+```
+
+手元ではこの1行で、workerが実行されない現象を毎回再現できました。
+
+修正はspawn直前の`trap '' HUP`です。シグナルを無視する設定(disposition)は、fork()で子にコピーされ、execve()を越えても保持されます。ハンドラを設定したシグナルはexecでデフォルトへ戻りますが、無視だけは残ります。この無視設定はsetsidとbashへのexecを経ても維持されるので、`setsid(2)`の完了前にSIGHUPが届いても子は死にません。setsid完了後は制御端末を持たない新しいセッションに入るため、以後はPTYの破棄自体が届きません。
+
+sleepで親のexitを遅らせる案もありましたが、PTY破棄のタイミングはherdr側の実装次第で変わるため、タイミング依存の回避策にしかなりません。dispositionの継承はPOSIXで規定された動作なので、こちらを採りました。
+
+## 学び4: 実装言語の相場と共通の罠
+
+bash 112行という実装が、herdrプラグインとして妥当な規模なのか、そもそもシェルスクリプトで実装するのがよいのかが気になりました。そこで、GitHubのtopic `herdr-plugin`が付いたリポジトリをstar順に10個と、同種のプラグインである`crafts69guy/herdr-ghq`を調査しました。
+
+star順の結果は次のとおりです(star数と行数は2026年8月の調査時点のもの)。
+
+| リポジトリ | star | 実装 |
+| --- | --- | --- |
+| openclaw/crabbox | 1250 | sh 124行 + Go CLIへの委譲 |
+| madarco/agentbox | 333 | TypeScript/Node、herdr層760行、ソケット+CLI |
+| smarzban/herdr-file-viewer | 327 | Rust、29,000行のTUI |
+| persiyanov/herdr-reviewr | 313 | Rust、22,000行のTUI |
+| ogulcancelik/herdr-browser | 245 | TypeScript/Bun直実行、依存ゼロ、ビルドなし |
+| AltanS/collie | 227 | TypeScript/Bun 6,300行 + sh 828行、.env設定 |
+| cloudmanic/herdr-plus | 194 | Go 3,700行のTUI、1アイテム1 TOML設定 |
+| dcolinmorgan/herdr-remote | 172 | Python、フックは20行 |
+| nikok6/herdr-mirror | 88 | Rust 8,500行、ソケット直結 |
+| edmundmiller/dotfiles | 77 | Python標準ライブラリ、66〜282行のプラグインを3つ、完全ゼロコンフィグ |
+| crafts69guy/herdr-ghq | (類似プラグイン) | Rust 9,100行 + bash 1,100行、fzfを捨てて自前のratatui TUI |
+
+fzfのような既存のピッカーに乗るならシェルスクリプトで足ります。Rust、Goで数千行から数万行になっているのは、ピッカーやビューアのUIを自前で持つ実装です。扱う機能が1つで100行規模の本プラグインでは、シェルスクリプトでよさそうなことがわかります。
+
+実装の規約も読み取れました。設定を持つプラグインは`HERDR_PLUGIN_CONFIG_DIR`配下にプラグイン所有のTOMLを置き、ファイルが無ければ全項目デフォルトで動きます。herdrの呼び出しは`${HERDR_BIN_PATH:-herdr}`のCLIサブプロセスが標準で、ソケットへの直結はイベント購読が必要な実装に限られていました。
+
+調べた実装には共通の罠もありました。PATHの解決失敗、paneの破棄による子プロセスの死、paneのcwdがプラグインのルートと一致しない問題の3つで、前の2つは私も踏んだものです。paneの破棄による子プロセスの死について、Rust実装の`crafts69guy/herdr-ghq`は`Command::process_group(0)`とstdioのnull接続で対処していました。`process_group(0)`はexecの前に子プロセスで`setpgid(0, 0)`を呼び、子を新しいプロセスグループへ移します。hangupのSIGHUPはフォアグラウンドプロセスグループへ送られるため、別グループへ移った子には届きません。私の`trap '' HUP`が「シグナルを無視して隙間を越える」解だとすれば、こちらは「シグナルの宛先から外れる」解で、同じ競合への別解です。
+
+## マーケットプレイスへの公開
+
+git initしてコミットし、`gh repo create kenchan/herdr-ghq-open-agent --public --source . --push`で公開しました。herdrのマーケットプレイスに専用の登録手続きはありません。GitHubのtopicに`herdr-plugin`を付けるだけで、30分ごとの自動インデックスで掲載されます。
+
+## まとめ
+
+ghqとfzfでclaudeを起動するherdrプラグインを作り、マーケットプレイスに公開しました。得た学びを再掲します。
+
+- `shell`型キーバインドは`/bin/sh -lc`で実行され、`/etc/profile`がPATHを上書きする。バイナリは注入される`HERDR_BIN_PATH`の絶対パスで呼ぶ
+- popupはコマンドの終了で閉じる。時間のかかる同期処理はdetachedなworkerへ切り離し、popupフェーズは即exitさせる
+- 親の即exitによるPTYの破棄はSIGHUPになり、fork()から`setsid(2)`までの隙間にいる子プロセスを殺す。spawn前の`trap '' HUP`で塞ぐ
+- herdrプラグインOSSが十分にあるので先に調査しよう。既存のピッカーに乗るならシェルスクリプト、ピッカーUIを自前で持つならRustやGoの実装が参考になる
+
+リポジトリは[kenchan/herdr-ghq-open-agent](https://github.com/kenchan/herdr-ghq-open-agent)です。同じ構成のプラグインを書くときの参考になればうれしいです。


### PR DESCRIPTION
## 概要

「ghqとfzfでclaudeを起動するherdrプラグインを作って学んだこと」の下書き(published: false)を追加します。

## 内容

- 作ったもの: [herdr-ghq-open-agent](https://github.com/kenchan/herdr-ghq-open-agent)の紹介(インストール、キーバインド、仕組み)
- 学び1: type = "shell"はログインシェルで実行される(PATHリセットとHERDR_BIN_PATH)
- 学び2: popupの寿命と同期処理の分離(2フェーズ化)
- 学び3: fork()とsetsid()のあいだのSIGHUP競合(script(1)での再現とtrap '' HUP)
- 学び4: エコシステム調査による実装言語の相場と共通の罠

## 補足

- 記事中の主張はherdr本体のソース・CHANGELOG・docs・実機での再現テストで検証済み
- textlintはクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5zBLKQNWciN15JTbbJsgU